### PR TITLE
feat: Add specific credential selection for iOS authentication

### DIFF
--- a/ios/Passkey.m
+++ b/ios/Passkey.m
@@ -14,6 +14,7 @@ RCT_EXTERN_METHOD(register:(NSString)identifier
 RCT_EXTERN_METHOD(authenticate:(NSString)identifier
                   withChallenge:(NSString)challenge
                   withSecurityKey:(BOOL) securityKey
+                  withCredentialId:(NSString *)credentialId
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);
 

--- a/ios/Passkey.swift
+++ b/ios/Passkey.swift
@@ -89,10 +89,15 @@ class Passkey: NSObject {
         let authRequest = securityKeyProvider.createCredentialAssertionRequest(challenge: challengeData);
         authController = ASAuthorizationController(authorizationRequests: [authRequest]);
       } else {
-        // Create a new assertion request without security key
-        let platformProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: identifier);
-        let authRequest = platformProvider.createCredentialAssertionRequest(challenge: challengeData);
-        authController = ASAuthorizationController(authorizationRequests: [authRequest]);
+          // Create a new assertion request without security key
+          let platformProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: identifier);
+          let authRequest = platformProvider.createCredentialAssertionRequest(challenge: challengeData);
+          
+          if let credentialId = credentialId {
+            authRequest.allowedCredentials = [ASAuthorizationPlatformPublicKeyCredentialDescriptor(credentialID: Data.fromBase64Url(credentialId)!)]
+          }
+          
+          authController = ASAuthorizationController(authorizationRequests: [authRequest]);
       }
 
       // Set up a PasskeyDelegate instance with a callback function

--- a/src/PasskeyiOS.tsx
+++ b/src/PasskeyiOS.tsx
@@ -82,7 +82,8 @@ export class PasskeyiOS {
       const response = await NativePasskey.authenticate(
         request.rpId,
         request.challenge,
-        withSecurityKey
+        withSecurityKey,
+        request.allowCredentials?.[0]?.id ?? null
       );
       return this.handleNativeAuthenticationResult(response);
     } catch (error) {


### PR DESCRIPTION
This PR updates the iOS Native Module for passkey to allow specifying the allowedCredentials.